### PR TITLE
Update javascript.md

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -2219,7 +2219,7 @@ The following guide is for ES6. If your team is using Typescript some of the rul
     }
 
     // bad
-    function fight () {
+    function fight() {
       console.log ('Swooosh!');
     }
 


### PR DESCRIPTION
This fixes a potential typo.

In example [19.3](https://github.com/VML/styleguide/blob/master/javascript.md#whitespace--around-keywords), a space after the function name is a rule often referred to as ```"space-before-function-paren"```. This rule is more of a stylistic preference; whereas, I believe, the intention for rule [19.3](https://github.com/VML/styleguide/blob/master/javascript.md#whitespace--around-keywords) is to guide users to not leave a space before the function parentheses of a *function call*.